### PR TITLE
Some important improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bool: Drift::IsPlayerDrifting(playerid);
 
 ```pawn
 forward	OnPlayerDriftStart(playerid);
-forward	OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed);
+forward	OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed, Float: distance, time);
 forward	OnPlayerDriftEnd(playerid, reason, Float: distance, time);
 ```
 

--- a/drift-detection.inc
+++ b/drift-detection.inc
@@ -68,7 +68,7 @@ enum e_DRIFT_PLAYER_STRUCT {
 #endif 
 
 #if defined OnPlayerDriftUpdate
-    forward	OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed);
+    forward	OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed, Float: distance, time);
 #endif
 
 #if defined OnPlayerDriftEnd
@@ -99,7 +99,7 @@ public OnPlayerUpdate(playerid)
 {
     if(g_DriftFlags & DRIFT_CHECK_ENABLED && g_DriftPlayers[playerid][playerFlags] & DRIFT_CHECK_ENABLED)
     {
-        if(GetTickCount() > g_DriftPlayers[playerid][lastTimestamp])
+        if(tickcount() > g_DriftPlayers[playerid][lastTimestamp])
         {
             new vehicleID = GetPlayerVehicleID(playerid);
             if(vehicleID && GetPlayerState(playerid) == PLAYER_STATE_DRIVER && IsModelACar(GetVehicleModel(vehicleID)))
@@ -134,7 +134,7 @@ public OnPlayerUpdate(playerid)
                         if(g_MinDriftAngle <= driftAngle <= MAX_DRIFT_ANGLE && speed >= g_MinDriftSpeed)
                         {                        
                             g_DriftPlayers[playerid][driftState] = DRIFT_STATE_DRIFTING;
-                            g_DriftPlayers[playerid][startTimestamp] = GetTickCount();
+                            g_DriftPlayers[playerid][startTimestamp] = tickcount();
 
                             GetVehicleHealth(vehicleID, g_DriftPlayers[playerid][vHealth]);
                             GetPlayerPos(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
@@ -162,7 +162,7 @@ public OnPlayerUpdate(playerid)
                                     new Float: distance;
                                     distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
 
-                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, GetTickCount() - g_DriftPlayers[playerid][startTimestamp]);
+                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
                                 #endif
                             }
                         }
@@ -171,7 +171,10 @@ public OnPlayerUpdate(playerid)
                             g_DriftPlayers[playerid][timeoutTicks] = 0;
                             
                             #if defined OnPlayerDriftUpdate
-                                OnPlayerDriftUpdate(playerid, driftAngle, speed);
+								new Float: distance;
+								distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
+                                
+								OnPlayerDriftUpdate(playerid, driftAngle, speed, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
                             #endif
                         }
                         else
@@ -189,14 +192,14 @@ public OnPlayerUpdate(playerid)
                                     new Float: distance;
                                     distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
 
-                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_TIMEOUT, distance, GetTickCount() - g_DriftPlayers[playerid][startTimestamp]);
+                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_TIMEOUT, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
                                 #endif
                             }
                         }
                     }
                 }
             }
-            g_DriftPlayers[playerid][lastTimestamp] = GetTickCount() + DRIFT_PROCESS_INTERVAL;
+            g_DriftPlayers[playerid][lastTimestamp] = tickcount() + DRIFT_PROCESS_INTERVAL;
         }
     }
     #if defined Drift_OnPlayerUpdate
@@ -219,7 +222,7 @@ public OnPlayerStateChange(playerid, newstate, oldstate)
             new Float: distance;
             distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
 
-            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, GetTickCount() - g_DriftPlayers[playerid][startTimestamp]);
+            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
         #endif
     }
 
@@ -244,11 +247,38 @@ public OnPlayerDisconnect(playerid, reason)
             new Float: distance;
             distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
 
-            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, GetTickCount() - g_DriftPlayers[playerid][startTimestamp]);
+            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
         #endif
     }
     #if defined Drift_OnPlayerDisconnect
         return Drift_OnPlayerDisconnect(playerid, reason);
+    #else
+        return true;
+    #endif
+}
+
+public OnVehicleDamageStatusUpdate(vehicleid, playerid)
+{
+	if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
+    {
+		if(g_DriftFlags & DAMAGE_CHECK_ENABLED && g_DriftPlayers[playerid][playerFlags] & DAMAGE_CHECK_ENABLED)
+		{
+			new Float: pX, Float: pY, Float: pZ;
+			GetPlayerPos(playerid, pX, pY, pZ);
+
+			g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
+			g_DriftPlayers[playerid][timeoutTicks] = 0;
+
+			#if defined OnPlayerDriftEnd
+				new Float: distance;
+				distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
+			
+				OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+			#endif
+		}
+    }
+    #if defined Drift_OnVehicleDamageStatusUpd
+        return Drift_OnVehicleDamageStatusUpd(vehicleid, playerid);
     #else
         return true;
     #endif
@@ -334,6 +364,17 @@ stock bool: Drift::IsPlayerDrifting(playerid)
 {
     return !!g_DriftPlayers[playerid][driftState];
 }
+
+#if defined _ALS_OnVehicleDamageStatusUpd
+    #undef OnVehicleDamageStatusUpdate
+#else
+    #define _ALS_OnVehicleDamageStatusUpd
+#endif
+
+#define OnVehicleDamageStatusUpdate Drift_OnVehicleDamageStatusUpd
+#if defined Drift_OnVehicleDamageStatusUpd
+    forward Drift_OnVehicleDamageStatusUpd(vehicleid, playerid);
+#endif
 
 #if defined _ALS_OnPlayerDisconnect
     #undef OnPlayerDisconnect

--- a/drift-detection.inc
+++ b/drift-detection.inc
@@ -32,7 +32,8 @@
 enum {
     DRIFT_END_REASON_TIMEOUT, 
     DRIFT_END_REASON_DAMAGED, 
-    DRIFT_END_REASON_OTHER 
+    DRIFT_END_REASON_OTHER,
+	DRIFT_END_REASON_CANCELED
 }
 // drift states
 enum {
@@ -363,6 +364,24 @@ stock bool: Drift::IsDamageCheckEnabled(playerid = -1)
 stock bool: Drift::IsPlayerDrifting(playerid)
 {
     return !!g_DriftPlayers[playerid][driftState];
+}
+stock Drift::CancelPlayerDrift(playerid)
+{
+    if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
+    {
+        new Float: pX, Float: pY, Float: pZ;
+        GetPlayerPos(playerid, pX, pY, pZ);
+                
+        g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
+        g_DriftPlayers[playerid][timeoutTicks] = 0;   
+
+        #if defined OnPlayerDriftEnd
+            new Float: distance;
+            distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
+
+            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_CANCELED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+        #endif
+    }
 }
 
 #if defined _ALS_OnVehicleDamageStatusUpd

--- a/drift-detection.inc
+++ b/drift-detection.inc
@@ -6,7 +6,7 @@
 	Latest Update Date:
 		16-Feb-2018
 	Version:
-		1.2.0
+		1.1.0
 */
 
 // include guard to avoid duplication
@@ -25,8 +25,8 @@
 #define MAX_DRIFT_ANGLE     (80.0)  // maximum drift angle to start a drift
 #define MIN_DRIFT_SPEED     (45.0)  // minimum speed to start a drift
 
-#define DRIFT_PROCESS_INTERVAL    (250)     // delay interval between each tick in ms
-#define DRIFT_TIMEOUT_INTERVAL    (6)       // how much ticks before a drift ends after the player stops drifting
+#define DRIFT_PROCESS_INTERVAL    (100)     // delay interval between each tick in ms
+#define DRIFT_TIMEOUT_INTERVAL    (10)       // how much ticks before a drift ends after the player stops drifting
 
 // drift ending reasons
 enum {
@@ -54,8 +54,11 @@ enum e_DRIFT_PLAYER_STRUCT {
     Float:  startPosY,
     Float:  startPosZ,
 
+	Float: driftDistance,
+	driftTime,
 	driftVehicle,
     driftState,
+	
     startTimestamp,
     lastTimestamp,
     timeoutTicks,
@@ -138,6 +141,8 @@ public OnPlayerUpdate(playerid)
                             g_DriftPlayers[playerid][driftState] = DRIFT_STATE_DRIFTING;
                             g_DriftPlayers[playerid][startTimestamp] = tickcount();
 							g_DriftPlayers[playerid][driftVehicle] = vehicleID;
+							g_DriftPlayers[playerid][driftTime] = 0;
+							g_DriftPlayers[playerid][driftDistance] = 0.0;
 
                             GetVehicleHealth(vehicleID, g_DriftPlayers[playerid][vHealth]);
                             GetVehiclePos(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
@@ -158,11 +163,9 @@ public OnPlayerUpdate(playerid)
                             {
                                 g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
                                 g_DriftPlayers[playerid][timeoutTicks] = 0;
-								g_DriftPlayers[playerid][driftVehicle] = 0;
 
                                 #if defined OnPlayerDriftEnd
-                                    new Float:distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
                                 #endif
 								
 								#if defined Drift_OnPlayerUpdate
@@ -175,10 +178,12 @@ public OnPlayerUpdate(playerid)
                         if(g_MinDriftAngle <= driftAngle <= MAX_DRIFT_ANGLE && speed >= g_MinDriftSpeed)
                         {
                             g_DriftPlayers[playerid][timeoutTicks] = 0;
+							g_DriftPlayers[playerid][driftTime] = ((tickcount() - g_DriftPlayers[playerid][startTimestamp])/1000);
                             
                             #if defined OnPlayerDriftUpdate
-								new Float:distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-								OnPlayerDriftUpdate(playerid, driftAngle, speed, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+								g_DriftPlayers[playerid][driftDistance] += GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
+								GetVehiclePos(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
+								OnPlayerDriftUpdate(playerid, driftAngle, speed, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
                             #endif
                         }
                         else
@@ -189,11 +194,9 @@ public OnPlayerUpdate(playerid)
                             {
                                 g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
                                 g_DriftPlayers[playerid][timeoutTicks] = 0;
-								g_DriftPlayers[playerid][driftVehicle] = 0;
 
                                 #if defined OnPlayerDriftEnd
-                                    new Float:distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_TIMEOUT, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+                                    OnPlayerDriftEnd(playerid, DRIFT_END_REASON_TIMEOUT, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
                                 #endif
                             }
                         }
@@ -213,14 +216,11 @@ public OnPlayerStateChange(playerid, newstate, oldstate)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING && oldstate == PLAYER_STATE_DRIVER)
     {
-		new Float: distance,vehicleID = g_DriftPlayers[playerid][driftVehicle];
         g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
         g_DriftPlayers[playerid][timeoutTicks] = 0;
-		g_DriftPlayers[playerid][driftVehicle] = 0;
 
         #if defined OnPlayerDriftEnd
-            distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
         #endif
     }
 
@@ -235,14 +235,11 @@ public OnPlayerDisconnect(playerid, reason)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
     { 
-        new Float: distance,vehicleID = g_DriftPlayers[playerid][driftVehicle];
         g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
-        g_DriftPlayers[playerid][timeoutTicks] = 0;
-		g_DriftPlayers[playerid][driftVehicle] = 0;   
+        g_DriftPlayers[playerid][timeoutTicks] = 0; 
 
         #if defined OnPlayerDriftEnd
-            distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
         #endif
     }
     #if defined Drift_OnPlayerDisconnect
@@ -260,11 +257,9 @@ public OnVehicleDamageStatusUpdate(vehicleid, playerid)
 		{
 			g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
 			g_DriftPlayers[playerid][timeoutTicks] = 0;
-			g_DriftPlayers[playerid][driftVehicle] = 0;
 
 			#if defined OnPlayerDriftEnd
-				new Float:distance = GetVehicleDistanceFromPoint(vehicleid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-				OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+				OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
 			#endif
 		}
     }
@@ -359,14 +354,11 @@ stock Drift::CancelPlayerDrift(playerid)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
     {  
-        new Float: distance,vehicleID = g_DriftPlayers[playerid][driftVehicle];
         g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
-        g_DriftPlayers[playerid][timeoutTicks] = 0;
-		g_DriftPlayers[playerid][driftVehicle] = 0;   
+        g_DriftPlayers[playerid][timeoutTicks] = 0;   
 
         #if defined OnPlayerDriftEnd
-            distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_CANCELED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
+            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_CANCELED, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
         #endif
     }
 }

--- a/drift-detection.inc
+++ b/drift-detection.inc
@@ -6,7 +6,7 @@
 	Latest Update Date:
 		16-Feb-2018
 	Version:
-		1.1.0
+		1.2.0
 */
 
 // include guard to avoid duplication
@@ -54,6 +54,7 @@ enum e_DRIFT_PLAYER_STRUCT {
     Float:  startPosY,
     Float:  startPosZ,
 
+	driftVehicle,
     driftState,
     startTimestamp,
     lastTimestamp,
@@ -136,9 +137,10 @@ public OnPlayerUpdate(playerid)
                         {                        
                             g_DriftPlayers[playerid][driftState] = DRIFT_STATE_DRIFTING;
                             g_DriftPlayers[playerid][startTimestamp] = tickcount();
+							g_DriftPlayers[playerid][driftVehicle] = vehicleID;
 
                             GetVehicleHealth(vehicleID, g_DriftPlayers[playerid][vHealth]);
-                            GetPlayerPos(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
+                            GetVehiclePos(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
                             
                             #if defined OnPlayerDriftStart
                                 OnPlayerDriftStart(playerid);
@@ -154,17 +156,20 @@ public OnPlayerUpdate(playerid)
 
                             if(vehicleHealth < g_DriftPlayers[playerid][vHealth])
                             {
-                                GetPlayerPos(playerid, vX, vY, vZ);
-
                                 g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
                                 g_DriftPlayers[playerid][timeoutTicks] = 0;
+								g_DriftPlayers[playerid][driftVehicle] = 0;
 
                                 #if defined OnPlayerDriftEnd
-                                    new Float: distance;
-                                    distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-
+                                    new Float:distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
                                     OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
                                 #endif
+								
+								#if defined Drift_OnPlayerUpdate
+									return Drift_OnPlayerUpdate(playerid);
+								#else
+									return true;
+								#endif
                             }
                         }
                         if(g_MinDriftAngle <= driftAngle <= MAX_DRIFT_ANGLE && speed >= g_MinDriftSpeed)
@@ -172,9 +177,7 @@ public OnPlayerUpdate(playerid)
                             g_DriftPlayers[playerid][timeoutTicks] = 0;
                             
                             #if defined OnPlayerDriftUpdate
-								new Float: distance;
-								distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-                                
+								new Float:distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
 								OnPlayerDriftUpdate(playerid, driftAngle, speed, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
                             #endif
                         }
@@ -184,15 +187,12 @@ public OnPlayerUpdate(playerid)
 
                             if(g_DriftPlayers[playerid][timeoutTicks] >= g_DriftTimeoutTicks)
                             {
-                                GetPlayerPos(playerid, vX, vY, vZ);
-                                
                                 g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
                                 g_DriftPlayers[playerid][timeoutTicks] = 0;
+								g_DriftPlayers[playerid][driftVehicle] = 0;
 
                                 #if defined OnPlayerDriftEnd
-                                    new Float: distance;
-                                    distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-
+                                    new Float:distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
                                     OnPlayerDriftEnd(playerid, DRIFT_END_REASON_TIMEOUT, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
                                 #endif
                             }
@@ -213,16 +213,13 @@ public OnPlayerStateChange(playerid, newstate, oldstate)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING && oldstate == PLAYER_STATE_DRIVER)
     {
-        new Float: pX, Float: pY, Float: pZ;
-        GetPlayerPos(playerid, pX, pY, pZ);
-
+		new Float: distance,vehicleID = g_DriftPlayers[playerid][driftVehicle];
         g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
         g_DriftPlayers[playerid][timeoutTicks] = 0;
+		g_DriftPlayers[playerid][driftVehicle] = 0;
 
         #if defined OnPlayerDriftEnd
-            new Float: distance;
-            distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-
+            distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
             OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
         #endif
     }
@@ -237,17 +234,14 @@ public OnPlayerStateChange(playerid, newstate, oldstate)
 public OnPlayerDisconnect(playerid, reason)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
-    {
-        new Float: pX, Float: pY, Float: pZ;
-        GetPlayerPos(playerid, pX, pY, pZ);
-                
+    { 
+        new Float: distance,vehicleID = g_DriftPlayers[playerid][driftVehicle];
         g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
-        g_DriftPlayers[playerid][timeoutTicks] = 0;   
+        g_DriftPlayers[playerid][timeoutTicks] = 0;
+		g_DriftPlayers[playerid][driftVehicle] = 0;   
 
         #if defined OnPlayerDriftEnd
-            new Float: distance;
-            distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-
+            distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
             OnPlayerDriftEnd(playerid, DRIFT_END_REASON_OTHER, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
         #endif
     }
@@ -264,16 +258,12 @@ public OnVehicleDamageStatusUpdate(vehicleid, playerid)
     {
 		if(g_DriftFlags & DAMAGE_CHECK_ENABLED && g_DriftPlayers[playerid][playerFlags] & DAMAGE_CHECK_ENABLED)
 		{
-			new Float: pX, Float: pY, Float: pZ;
-			GetPlayerPos(playerid, pX, pY, pZ);
-
 			g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
 			g_DriftPlayers[playerid][timeoutTicks] = 0;
+			g_DriftPlayers[playerid][driftVehicle] = 0;
 
 			#if defined OnPlayerDriftEnd
-				new Float: distance;
-				distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-			
+				new Float:distance = GetVehicleDistanceFromPoint(vehicleid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
 				OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
 			#endif
 		}
@@ -368,17 +358,14 @@ stock bool: Drift::IsPlayerDrifting(playerid)
 stock Drift::CancelPlayerDrift(playerid)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
-    {
-        new Float: pX, Float: pY, Float: pZ;
-        GetPlayerPos(playerid, pX, pY, pZ);
-                
+    {  
+        new Float: distance,vehicleID = g_DriftPlayers[playerid][driftVehicle];
         g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
-        g_DriftPlayers[playerid][timeoutTicks] = 0;   
+        g_DriftPlayers[playerid][timeoutTicks] = 0;
+		g_DriftPlayers[playerid][driftVehicle] = 0;   
 
         #if defined OnPlayerDriftEnd
-            new Float: distance;
-            distance = GetPlayerDistanceFromPoint(playerid, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
-
+            distance = GetVehicleDistanceFromPoint(vehicleID, g_DriftPlayers[playerid][startPosX], g_DriftPlayers[playerid][startPosY], g_DriftPlayers[playerid][startPosZ]);
             OnPlayerDriftEnd(playerid, DRIFT_END_REASON_CANCELED, distance, tickcount() - g_DriftPlayers[playerid][startTimestamp]);
         #endif
     }

--- a/drift-detection.inc
+++ b/drift-detection.inc
@@ -38,7 +38,8 @@ enum {
 // drift states
 enum {
     DRIFT_STATE_NONE,
-    DRIFT_STATE_DRIFTING
+    DRIFT_STATE_DRIFTING,
+	DRIFT_STATE_CANCELED
 }
 
 // option flags
@@ -107,6 +108,21 @@ public OnPlayerUpdate(playerid)
         if(tickcount() > g_DriftPlayers[playerid][lastTimestamp])
         {
             new vehicleID = GetPlayerVehicleID(playerid);
+			if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_CANCELED)
+			{
+				g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
+                g_DriftPlayers[playerid][timeoutTicks] = 0;
+								
+				#if defined OnPlayerDriftEnd
+					OnPlayerDriftEnd(playerid, DRIFT_END_REASON_CANCELED, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
+				#endif
+				
+				#if defined Drift_OnPlayerUpdate
+					return Drift_OnPlayerUpdate(playerid);
+				#else
+					return true;
+				#endif
+			}
             if(vehicleID && GetPlayerState(playerid) == PLAYER_STATE_DRIVER && IsModelACar(GetVehicleModel(vehicleID)))
             {
                 new Float: vX, Float: vY, Float: vZ;
@@ -333,13 +349,10 @@ stock Drift::CancelPlayerDrift(playerid)
 {
     if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
     {  
-        g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
+        g_DriftPlayers[playerid][driftState] = DRIFT_STATE_CANCELED;
         g_DriftPlayers[playerid][timeoutTicks] = 0;   
-
-        #if defined OnPlayerDriftEnd
-            OnPlayerDriftEnd(playerid, DRIFT_END_REASON_CANCELED, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
-        #endif
     }
+	return true;
 }
 
 #if defined _ALS_OnPlayerDisconnect

--- a/drift-detection.inc
+++ b/drift-detection.inc
@@ -249,27 +249,6 @@ public OnPlayerDisconnect(playerid, reason)
     #endif
 }
 
-public OnVehicleDamageStatusUpdate(vehicleid, playerid)
-{
-	if(g_DriftPlayers[playerid][driftState] == DRIFT_STATE_DRIFTING)
-    {
-		if(g_DriftFlags & DAMAGE_CHECK_ENABLED && g_DriftPlayers[playerid][playerFlags] & DAMAGE_CHECK_ENABLED)
-		{
-			g_DriftPlayers[playerid][driftState] = DRIFT_STATE_NONE;
-			g_DriftPlayers[playerid][timeoutTicks] = 0;
-
-			#if defined OnPlayerDriftEnd
-				OnPlayerDriftEnd(playerid, DRIFT_END_REASON_DAMAGED, g_DriftPlayers[playerid][driftDistance], g_DriftPlayers[playerid][driftTime]);
-			#endif
-		}
-    }
-    #if defined Drift_OnVehicleDamageStatusUpd
-        return Drift_OnVehicleDamageStatusUpd(vehicleid, playerid);
-    #else
-        return true;
-    #endif
-}
-
 // option functions
 stock Drift::SetMinAngle(Float: angle)
 {
@@ -362,17 +341,6 @@ stock Drift::CancelPlayerDrift(playerid)
         #endif
     }
 }
-
-#if defined _ALS_OnVehicleDamageStatusUpd
-    #undef OnVehicleDamageStatusUpdate
-#else
-    #define _ALS_OnVehicleDamageStatusUpd
-#endif
-
-#define OnVehicleDamageStatusUpdate Drift_OnVehicleDamageStatusUpd
-#if defined Drift_OnVehicleDamageStatusUpd
-    forward Drift_OnVehicleDamageStatusUpd(vehicleid, playerid);
-#endif
 
 #if defined _ALS_OnPlayerDisconnect
     #undef OnPlayerDisconnect

--- a/test.pwn
+++ b/test.pwn
@@ -21,20 +21,20 @@ public OnPlayerCommandText(playerid, cmdtext[])
 }
 public OnPlayerDriftStart(playerid)
 {
-	GameTextForPlayer(playerid, "~g~Drift Started!", 1000, 6);
+	GameTextForPlayer(playerid, "~g~Drift Started!", 1000, 4);
 	return true;
 }
-public OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed)
+public OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed, Float: distance, time)
 {
 	new message[128];
 	format(message, sizeof message, "~g~Drifting!!~n~~b~Angle:~r~ %0.1f~n~~b~Speed: ~r~%0.1f", drift_angle, speed);
-	GameTextForPlayer(playerid, message, 1000, 6);
+	GameTextForPlayer(playerid, message, 3000, 4);
 	return true;
 }
 public OnPlayerDriftEnd(playerid, reason, Float: distance, time)
 {
 	new message[128];
-	format(message, sizeof message, "~g~Drift End!!~n~~b~Reason: ~r~%i~n~~b~Distance:~r~ %0.1f~n~~b~Time: ~r~%d", reason, distance, time / 1000);
-	GameTextForPlayer(playerid, message, 1000, 6);
-	return true; 
+	format(message, sizeof message, "~g~Drift End!!~n~~b~Reason:~r~ %d~n~~b~Distance:~r~ %0.1f~n~~b~Time: ~r~%d", reason, distance, time / 1000);
+	GameTextForPlayer(playerid, message, 3000, 4);
+	return true;
 }

--- a/test.pwn
+++ b/test.pwn
@@ -34,7 +34,7 @@ public OnPlayerDriftUpdate(playerid, Float: drift_angle, Float: speed, Float: di
 public OnPlayerDriftEnd(playerid, reason, Float: distance, time)
 {
 	new message[128];
-	format(message, sizeof message, "~g~Drift End!!~n~~b~Reason:~r~ %d~n~~b~Distance:~r~ %0.1f~n~~b~Time: ~r~%d", reason, distance, time / 1000);
+	format(message, sizeof message, "~g~Drift End!!~n~~b~Reason:~r~ %d~n~~b~Distance:~r~ %0.1f~n~~b~Time: ~r~%d", reason, distance, time);
 	GameTextForPlayer(playerid, message, 3000, 4);
 	return true;
 }


### PR DESCRIPTION
**Everything has been tested and is working correctly!**

**» Replaced `GetTickCount()` with `tickcount()`:**
- **GetTickCount** - Uptime of the actual server (not the SA-MP server) - This causes problems with servers using VPS, as they remain on for more than 24 days and simply restarting the machine doesn't reset the time, it requires restarting the entire server where the VPS is located.
- On the other hand, **tickcount** is reset every time samp-server.exe is restarted.

**» Added the `distance` and `time` parameters to `OnPlayerDriftUpdate`.**

**» Added a new useful function:**
`Drift::CancelPlayerDrift(playerid);`
`DRIFT_END_REASON_CANCELED`
`DRIFT_STATE_CANCELED`

**» Added `g_DriftPlayers[playerid][driftVehicle]`:**
- To save the vehicle with which the drift began.

**» Replaced `GetPlayerDistanceFromPoint` with `GetVehicleDistanceFromPoint`:**
- There's a difference between the player's position and the vehicle's position. The distance we need is the distance the vehicle actually traveled while drifting.

**» Code cleanup:**
- Removed unused `GetPlayerPos`.
- Other minor adjustments were made.

**» Reduced `DRIFT_PROCESS_INTERVAL` from `250` to `100`:**
- Allows the system to detect the start and end of a drift more quickly and accurately.

**» Increased the minimum `DRIFT_TIMEOUT_INTERVAL` from `6` to `10`:**
- To be proportional to the decrease in `DRIFT_PROCESS_INTERVAL`.

**» Added `g_DriftPlayers[playerid][driftTime]` and `g_DriftPlayers[playerid][driftDistance]`:**
- Saving this information more accurately is essential.
- Will only save while the player is actually drifting.